### PR TITLE
Automatically create service account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,6 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
-
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
-
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -18,6 +18,8 @@ See the [Airplane docs](https://docs.airplane.dev/self-hosting/storage) for more
 |------|------|
 | [google_compute_global_address.agent_external_server](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_redis_instance.agent_storage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) | resource |
+| [google_service_account.agent_storage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.workload_identity_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_storage_bucket.agent_storage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_member.policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [http_http.update_external_alb_dns](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
@@ -26,14 +28,16 @@ See the [Airplane docs](https://docs.airplane.dev/self-hosting/storage) for more
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Airplane API key - generate one via `airplane apikeys create`. | `string` | n/a | yes |
+| <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Airplane API key - generate one via `airplane apikeys create` | `string` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | GCP project name | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Region for agent | `string` | n/a | yes |
-| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email for service account | `string` | n/a | yes |
 | <a name="input_team_id"></a> [team\_id](#input\_team\_id) | Airplane team ID - retrieve via `airplane auth info` | `string` | n/a | yes |
 | <a name="input_agent_storage_domain"></a> [agent\_storage\_domain](#input\_agent\_storage\_domain) | For development purposes only | `string` | `"d.airplane.sh"` | no |
 | <a name="input_agent_storage_zone_slug"></a> [agent\_storage\_zone\_slug](#input\_agent\_storage\_zone\_slug) | Zone slug for use with self-hosted agent storage | `string` | `"gke"` | no |
 | <a name="input_api_host"></a> [api\_host](#input\_api\_host) | For development purposes only | `string` | `"https://api.airplane.dev"` | no |
-| <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Suffix to be added to all names; a dash will be automatically added at the beginning | `string` | `"gke"` | no |
+| <a name="input_kube_namespace"></a> [kube\_namespace](#input\_kube\_namespace) | Kubernetes namepsace that agents will run in; if unset, no binding will be made between the service account and GKE | `string` | `""` | no |
+| <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Suffix to be added to all names; if unset, the zone slug will be used | `string` | `""` | no |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email of an existing service account to use for the agent; if unset, a new service account will be created | `string` | `""` | no |
 
 ## Outputs
 
@@ -41,6 +45,7 @@ See the [Airplane docs](https://docs.airplane.dev/self-hosting/storage) for more
 |------|-------------|
 | <a name="output_agent_server_addr_name"></a> [agent\_server\_addr\_name](#output\_agent\_server\_addr\_name) | n/a |
 | <a name="output_agent_server_ip"></a> [agent\_server\_ip](#output\_agent\_server\_ip) | n/a |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | n/a |
 | <a name="output_storage_bucket_name"></a> [storage\_bucket\_name](#output\_storage\_bucket\_name) | n/a |
 | <a name="output_storage_redis_addr"></a> [storage\_redis\_addr](#output\_storage\_redis\_addr) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,5 +1,25 @@
+locals {
+  name_suffix = var.name_suffix != "" ? "-${var.name_suffix}" : "-${var.agent_storage_zone_slug}"
+}
+
+resource "google_service_account" "agent_storage" {
+  account_id   = "ap-agent-${local.name_suffix}"
+  display_name = "Airplane agent service account for zone"
+  count        = var.service_account_email != "" ? 1 : 0
+}
+
+resource "google_service_account_iam_member" "workload_identity_role" {
+  service_account_id = (
+    var.service_account_email != "" ?
+    var.service_account_email : google_service_account.agent_storage[0].id
+  )
+  role   = "roles/iam.workloadIdentityUser"
+  member = "serviceAccount:${var.project}.svc.id.goog[${var.kube_namespace}/airplane-agent]"
+  count  = var.kube_namespace != "" ? 1 : 0
+}
+
 resource "google_storage_bucket" "agent_storage" {
-  name          = "airplane-agent-storage-${var.name_suffix}"
+  name          = "airplane-agent-storage-${local.name_suffix}"
   location      = var.region
   storage_class = "STANDARD"
 
@@ -10,11 +30,11 @@ resource "google_storage_bucket" "agent_storage" {
 resource "google_storage_bucket_iam_member" "policy" {
   bucket = google_storage_bucket.agent_storage.name
   role   = "roles/storage.admin"
-  member = "serviceAccount:${var.service_account_email}"
+  member = "serviceAccount:${var.service_account_email != "" ? var.service_account_email : google_service_account.agent_storage[0].id}"
 }
 
 resource "google_redis_instance" "agent_storage" {
-  name           = "airplane-agent-storage-${var.name_suffix}"
+  name           = "airplane-agent-storage-${local.name_suffix}"
   tier           = "STANDARD_HA"
   region         = var.region
   memory_size_gb = 1
@@ -22,7 +42,7 @@ resource "google_redis_instance" "agent_storage" {
 }
 
 resource "google_compute_global_address" "agent_external_server" {
-  name = "agent-storage-${var.region}-${var.name_suffix}"
+  name = "agent-storage-${var.region}-${local.name_suffix}"
 }
 
 data "http" "update_external_alb_dns" {

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -7,7 +7,7 @@ output "agent_server_ip" {
 }
 
 output "service_account_email" {
-  value = var.service_account_email != "" ? var.service_account_email : google_storage_bucket.agent_storage[0].name
+  value = var.service_account_email != "" ? var.service_account_email : google_service_account.agent_storage[0].email
 }
 
 output "storage_bucket_name" {

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -6,6 +6,10 @@ output "agent_server_ip" {
   value = google_compute_global_address.agent_external_server.address
 }
 
+output "service_account_email" {
+  value = var.service_account_email != "" ? var.service_account_email : google_storage_bucket.agent_storage[0].name
+}
+
 output "storage_bucket_name" {
   value = google_storage_bucket.agent_storage.name
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -18,14 +18,25 @@ variable "api_host" {
 
 variable "api_token" {
   type        = string
-  description = "Airplane API key - generate one via `airplane apikeys create`."
+  description = "Airplane API key - generate one via `airplane apikeys create`"
   sensitive   = true
 }
 
 variable "name_suffix" {
   type        = string
-  description = "Suffix to be added to all names; a dash will be automatically added at the beginning"
-  default     = "gke"
+  description = "Suffix to be added to all names; if unset, the zone slug will be used"
+  default     = ""
+}
+
+variable "kube_namespace" {
+  type        = string
+  description = "Kubernetes namepsace that agents will run in; if unset, no binding will be made between the service account and GKE"
+  default     = ""
+}
+
+variable "project" {
+  type        = string
+  description = "GCP project name"
 }
 
 variable "region" {
@@ -35,7 +46,8 @@ variable "region" {
 
 variable "service_account_email" {
   type        = string
-  description = "Email for service account"
+  description = "Email of an existing service account to use for the agent; if unset, a new service account will be created"
+  default     = ""
 }
 
 variable "team_id" {


### PR DESCRIPTION
## Description
This change updates our GKE storage terraform module to optionally create a service account if an existing one is not provided. It also sets a default for the name suffix and adds the GCP->GKE service account binding if a kube namespace is provided.

These changes should reduce the amount of boilerplate that users need to set up self-hosted agents with GKE.

## Testing
Testing completed successfully via applying locally both with and without an existing service account.