### PR TITLE
Support auth for GCP memorystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This repo contains various Terraform modules for running self-hosted Airplane
 agents in GCP.
 
-See the [Airplane GCP docs](https://docs.airplane.dev/self-hosting/gcp) for more details.
+See the [Airplane self-hosting docs](https://docs.airplane.dev/self-hosting/gcp) for more details.

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -38,6 +38,9 @@ See the [Airplane docs](https://docs.airplane.dev/self-hosting/storage) for more
 | <a name="input_kube_namespace"></a> [kube\_namespace](#input\_kube\_namespace) | Kubernetes namepsace that agents will run in; if unset, no binding will be made between the service account and GKE | `string` | `""` | no |
 | <a name="input_kube_service_account_name"></a> [kube\_service\_account\_name](#input\_kube\_service\_account\_name) | Name of the agent service account in Kubernetes | `string` | `"airplane-agent"` | no |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Suffix to be added to all names; if unset, the zone slug will be used | `string` | `""` | no |
+| <a name="input_redis_auth_enabled"></a> [redis\_auth\_enabled](#input\_redis\_auth\_enabled) | Enable Redis username/password AUTH | `bool` | `false` | no |
+| <a name="input_redis_transit_encryption_mode"></a> [redis\_transit\_encryption\_mode](#input\_redis\_transit\_encryption\_mode) | Transit encryption for Redis instance. Set to either SERVER\_AUTHENTICATION to enable TLS or DISABLED. | `string` | `"DISABLED"` | no |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Version of redis to create | `string` | `"REDIS_7_0"` | no |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email of an existing service account to use for the agent; if unset, a new service account will be created | `string` | `""` | no |
 
 ## Outputs
@@ -49,4 +52,6 @@ See the [Airplane docs](https://docs.airplane.dev/self-hosting/storage) for more
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | n/a |
 | <a name="output_storage_bucket_name"></a> [storage\_bucket\_name](#output\_storage\_bucket\_name) | n/a |
 | <a name="output_storage_redis_addr"></a> [storage\_redis\_addr](#output\_storage\_redis\_addr) | n/a |
+| <a name="output_storage_redis_auth_string"></a> [storage\_redis\_auth\_string](#output\_storage\_redis\_auth\_string) | n/a |
+| <a name="output_storage_redis_ca_cert"></a> [storage\_redis\_ca\_cert](#output\_storage\_redis\_ca\_cert) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -40,6 +40,9 @@ resource "google_redis_instance" "agent_storage" {
   region         = var.region
   memory_size_gb = 1
   redis_version  = "REDIS_6_X"
+
+  auth_enabled            = var.redis_auth_enabled
+  transit_encryption_mode = var.redis_transit_encryption_mode
 }
 
 resource "google_compute_global_address" "agent_external_server" {

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -39,7 +39,7 @@ resource "google_redis_instance" "agent_storage" {
   tier           = "STANDARD_HA"
   region         = var.region
   memory_size_gb = 1
-  redis_version  = "REDIS_6_X"
+  redis_version  = var.redis_version
 
   auth_enabled            = var.redis_auth_enabled
   transit_encryption_mode = var.redis_transit_encryption_mode

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -14,6 +14,19 @@ output "storage_bucket_name" {
   value = google_storage_bucket.agent_storage.name
 }
 
+output "storage_redis_auth_string" {
+  value     = google_redis_instance.agent_storage.auth_string
+  sensitive = true
+}
+
 output "storage_redis_addr" {
   value = "${google_redis_instance.agent_storage.host}:${google_redis_instance.agent_storage.port}"
+}
+
+output "storage_redis_ca_cert" {
+  value = (
+    var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION"
+    ? google_redis_instance.agent_storage.server_ca_certs[0].cert
+    : ""
+  )
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -45,6 +45,18 @@ variable "project" {
   description = "GCP project name"
 }
 
+variable "redis_auth_enabled" {
+  type        = bool
+  description = "Enable Redis username/password AUTH"
+  default     = false
+}
+
+variable "redis_transit_encryption_mode" {
+  type        = string
+  description = "Transit encryption for redis instance. Set to either SERVER_AUTHENTICATION to enable TLS or DISABLED."
+  default     = "DISABLED"
+}
+
 variable "region" {
   type        = string
   description = "Region for agent"

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -53,8 +53,14 @@ variable "redis_auth_enabled" {
 
 variable "redis_transit_encryption_mode" {
   type        = string
-  description = "Transit encryption for redis instance. Set to either SERVER_AUTHENTICATION to enable TLS or DISABLED."
+  description = "Transit encryption for Redis instance. Set to either SERVER_AUTHENTICATION to enable TLS or DISABLED."
   default     = "DISABLED"
+}
+
+variable "redis_version" {
+  type        = string
+  description = "Version of redis to create"
+  default     = "REDIS_7_0"
 }
 
 variable "region" {


### PR DESCRIPTION
## Description
This change updates our GCP storage module to optionally support authenticated redis connections. It also makes the Redis version configurable and defaults it to 7.0 since GCP recently made that available.

## Testing
Testing completed successfully via applying in stage.