### PR TITLE
Set gcs bucket cors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This repo contains various Terraform modules for running self-hosted Airplane
 agents in GCP.
 
-See the [Airplane self-hosting docs](https://docs.airplane.dev/self-hosting/gcp) for more details.
+See the [Airplane GCP docs](https://docs.airplane.dev/self-hosting/gcp) for more details.

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -42,6 +42,7 @@ See the [Airplane docs](https://docs.airplane.dev/self-hosting/storage) for more
 | <a name="input_redis_transit_encryption_mode"></a> [redis\_transit\_encryption\_mode](#input\_redis\_transit\_encryption\_mode) | Transit encryption for Redis instance. Set to either SERVER\_AUTHENTICATION to enable TLS or DISABLED. | `string` | `"DISABLED"` | no |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Version of redis to create | `string` | `"REDIS_7_0"` | no |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email of an existing service account to use for the agent; if unset, a new service account will be created | `string` | `""` | no |
+| <a name="input_storage_bucket_allowed_origins"></a> [storage\_bucket\_allowed\_origins](#input\_storage\_bucket\_allowed\_origins) | List of allowed origins to include in agent storage bucket CORS config | `list(string)` | <pre>[<br>  "https://app.airplane.dev"<br>]</pre> | no |
 
 ## Outputs
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -26,6 +26,12 @@ resource "google_storage_bucket" "agent_storage" {
 
   public_access_prevention    = "enforced"
   uniform_bucket_level_access = true
+
+  cors {
+    origin          = var.storage_bucket_allowed_origins
+    method          = ["GET", "PUT", "POST"]
+    response_header = ["content-type", "x-goog-content-length-range"]
+  }
 }
 
 resource "google_storage_bucket_iam_member" "policy" {

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -76,7 +76,7 @@ variable "service_account_email" {
 
 variable "storage_bucket_allowed_origins" {
   type        = list(string)
-  description = "List of allowed origins to include in agent storage bucket CORS config"
+  description = "List of allowed origins to include in the agent storage bucket CORS config"
   default     = ["https://app.airplane.dev"]
 }
 

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -74,6 +74,12 @@ variable "service_account_email" {
   default     = ""
 }
 
+variable "storage_bucket_allowed_origins" {
+  type        = list(string)
+  description = "List of allowed origins to include in agent storage bucket CORS config"
+  default     = ["https://app.airplane.dev"]
+}
+
 variable "team_id" {
   type        = string
   description = "Airplane team ID - retrieve via `airplane auth info`"


### PR DESCRIPTION
# Description
This change updates our agent storage terraform module to set cors configurations on any GCS buckets created. This is needed so that uploads work properly from the Airplane FE in the self-hosted storage case.

# Testing
Testing to be completed via applying in our stage cluster.