### PR TITLE
Optionally specify Redis authorized network

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -47,7 +47,7 @@ resource "google_redis_instance" "agent_storage" {
   memory_size_gb = 1
   redis_version  = var.redis_version
 
-  authorized_network = var.redis_authorized_network
+  authorized_network      = var.redis_authorized_network
   auth_enabled            = var.redis_auth_enabled
   transit_encryption_mode = var.redis_transit_encryption_mode
 }

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -47,6 +47,7 @@ resource "google_redis_instance" "agent_storage" {
   memory_size_gb = 1
   redis_version  = var.redis_version
 
+  authorized_network = var.redis_authorized_network
   auth_enabled            = var.redis_auth_enabled
   transit_encryption_mode = var.redis_transit_encryption_mode
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -51,6 +51,12 @@ variable "redis_auth_enabled" {
   default     = false
 }
 
+variable "redis_authorized_network" {
+  type        = string
+  description = "The full name of the GCE network to which the instance is connected. If left unspecified, the default network will be used."
+  default     = null
+}
+
 variable "redis_transit_encryption_mode" {
   type        = string
   description = "Transit encryption for Redis instance. Set to either SERVER_AUTHENTICATION to enable TLS or DISABLED."


### PR DESCRIPTION
By default, the `google_redis_instance` resource creates a direct peer to the GCP project's `default` network. It is common to create a network for a GKE cluster, so it is useful to be able to specify the peered network so that an agent running in GKE on another network is able to use the peer.